### PR TITLE
feat(writing): /writing "Coming Soon" page + remove nav placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### 2026-06-29 — Writing "Coming Soon" page
+
+- `src/components/Nav.tsx`: pointed the **Writing** nav link at the new `/writing` route and removed the "Coming soon" placeholder treatment (the disabled `<span>` on desktop and the "Soon" badge on mobile). The link now renders as a regular nav item in both layouts.
+- `src/app/writing/page.tsx` (new): polished, vertically + horizontally centered "Coming Soon." page matching the design system. Instrument Serif display heading with dimmed first word, Visby CF eyebrow, Inter muted copy, a subtle lucide `PenLine` icon mark, and a pill CTA back to `/works`. Responsive via `clamp()` heading and fluid padding; no new dependencies or assets. `pnpm lint` passes.
+- `src/components/Footer.tsx`: pointed the footer's **Writing** link at `/writing` (was a `null` "Coming soon" placeholder), matching the navbar.
+- No-vertical-scroll on the writing page: the section centers via `flex-1` (`md:py-0`, no redundant `py-24`), and a scoped `body:has([data-fit-viewport]) footer { margin-top: 0 }` rule in `globals.css` drops the footer's standard 120px top gap on this page only. Verified zero overflow at 1920×1080, 1536×864, 1440×900, 1366×768, and 1280×720; the footer's gap is unchanged on all other pages.
+
 ### QA Session — 2026-05-29 ("Visit project" link for live works)
 
 **Agents employed:** `plinth-data-assets-integrator` (Phase 1 — data), `plinth-page-assembler` (Phase 2 — UI)

--- a/PLAN.md
+++ b/PLAN.md
@@ -36,5 +36,5 @@ Keep this lean. Remove completed work. Focus on active execution only.
 
 - PWA manifest and icons (already added per git history)
 - SEO metadata polish per page
-- Blog / article section (referenced in typography scale, Writing nav link is a placeholder)
+- Blog / article section (referenced in typography scale; `/writing` now ships a "Coming Soon" placeholder page and the Writing nav link points to it)
 - Light mode polish (dark-first, light mode is secondary)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -296,3 +296,10 @@
 [data-theme="light"] .theme-toggle__moon {
   display: block;
 }
+
+/* Full-viewport placeholder pages (e.g. /writing) center their content via
+   flex-1 and don't need the footer's standard top gap — dropping it lets the
+   nav + content + footer fit within the viewport without vertical scroll. */
+body:has([data-fit-viewport]) footer {
+  margin-top: 0;
+}

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,0 +1,75 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { PenLine, ArrowUpRight } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Writing",
+  description:
+    "Essays and notes on design, music, and code from Gilead Odo. Coming soon.",
+};
+
+export default function WritingPage() {
+  return (
+    <section
+      data-fit-viewport
+      className="mx-auto flex flex-1 flex-col items-center justify-center px-6 py-16 text-center md:px-12 md:py-0"
+      style={{ maxWidth: "var(--container-max)" }}
+    >
+      {/* Subtle icon mark */}
+      <div
+        className="mb-8 flex size-16 items-center justify-center rounded-full border"
+        style={{
+          backgroundColor: "var(--bg-icon)",
+          borderColor: "var(--border)",
+          color: "var(--text-primary)",
+        }}
+      >
+        <PenLine size={26} aria-hidden="true" />
+      </div>
+
+      <p
+        className="mb-4.5 flex items-center gap-2.5 text-sm font-semibold uppercase tracking-[0.08em] before:inline-block before:h-px before:w-4.5 before:bg-current before:content-[''] after:inline-block after:h-px after:w-4.5 after:bg-current after:content-['']"
+        style={{
+          fontFamily: "var(--font-heading)",
+          color: "var(--text-muted)",
+        }}
+      >
+        Writing
+      </p>
+
+      <h1
+        className="mb-6 leading-[0.98] tracking-[-0.06em]"
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "clamp(56px, 7vw, 96px)",
+          color: "var(--text-primary)",
+        }}
+      >
+        <span style={{ color: "var(--text-display-dim)" }}>Coming </span>
+        Soon.
+      </h1>
+
+      <p
+        className="mb-10 max-w-[52ch] text-[22px] leading-[1.4] tracking-[-0.03em]"
+        style={{ color: "var(--text-muted)" }}
+      >
+        I&rsquo;m building a place to share essays and notes on design, music,
+        and code. It&rsquo;s still in the works, so check back soon or explore
+        my projects in the meantime.
+      </p>
+
+      <Link
+        href="/works"
+        className="inline-flex h-12 items-center justify-center gap-2 rounded-full px-7 text-base font-medium transition-colors hover:bg-(--accent-primary) hover:text-(--text-on-accent)"
+        style={{
+          backgroundColor: "var(--text-primary)",
+          color: "var(--bg-page)",
+          fontFamily: "var(--font-heading)",
+        }}
+      >
+        Explore my work
+        <ArrowUpRight size={18} aria-hidden="true" />
+      </Link>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import { Logo } from "@/components/Logo";
 
 const navLinks = [
   { label: "Work", href: "/works" },
-  { label: "Writing", href: null },
+  { label: "Writing", href: "/writing" },
   { label: "About", href: "/about" },
   { label: "Contact", href: "/contact" },
 ];

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -18,7 +18,7 @@ import {
 
 const navLinks = [
   { label: "Work", href: "/works" },
-  { label: "Writing", href: null }, // placeholder — no route yet
+  { label: "Writing", href: "/writing" },
   { label: "About", href: "/about" },
   { label: "Contact", href: "/contact" },
 ];
@@ -73,36 +73,21 @@ export function Nav() {
             const active = isActive(link.href);
             return (
               <div key={link.label} className="relative">
-                {link.href ? (
-                  <Link
-                    href={link.href}
-                    className="flex min-h-11 items-center px-4 text-xl transition-colors"
-                    style={{
-                      fontFamily: "var(--font-heading)",
-                      fontWeight: 500,
-                      letterSpacing: "-0.02em",
-                      color: active
-                        ? "var(--text-primary, var(--foreground))"
-                        : "var(--text-muted, var(--muted-foreground))",
-                    }}
-                    aria-current={active ? "page" : undefined}
-                  >
-                    {link.label}
-                  </Link>
-                ) : (
-                  <span
-                    className="flex min-h-11 cursor-not-allowed items-center px-4 text-sm opacity-40"
-                    style={{
-                      fontFamily: "var(--font-heading)",
-                      fontWeight: 500,
-                      letterSpacing: "-0.02em",
-                      color: "var(--text-muted, var(--muted-foreground))",
-                    }}
-                    title="Coming soon"
-                  >
-                    {link.label}
-                  </span>
-                )}
+                <Link
+                  href={link.href}
+                  className="flex min-h-11 items-center px-4 text-xl transition-colors"
+                  style={{
+                    fontFamily: "var(--font-heading)",
+                    fontWeight: 500,
+                    letterSpacing: "-0.02em",
+                    color: active
+                      ? "var(--text-primary, var(--foreground))"
+                      : "var(--text-muted, var(--muted-foreground))",
+                  }}
+                  aria-current={active ? "page" : undefined}
+                >
+                  {link.label}
+                </Link>
                 {/* Active 2px lime underline below nav bar */}
                 {active && (
                   <span
@@ -182,27 +167,6 @@ export function Nav() {
               <nav className="flex flex-col gap-2" aria-label="Mobile primary">
                 {navLinks.map((link) => {
                   const active = isActive(link.href);
-
-                  if (!link.href) {
-                    return (
-                      <span
-                        key={link.label}
-                        className="flex min-h-12 cursor-not-allowed items-center justify-between rounded-2xl border px-4 text-lg opacity-50"
-                        style={{
-                          borderColor: "var(--border)",
-                          color: "var(--text-muted, var(--muted-foreground))",
-                          fontFamily: "var(--font-heading)",
-                          fontWeight: 500,
-                        }}
-                        title="Coming soon"
-                      >
-                        {link.label}
-                        <span className="text-xs uppercase tracking-[0.12em]">
-                          Soon
-                        </span>
-                      </span>
-                    );
-                  }
 
                   return (
                     <Link


### PR DESCRIPTION
## Summary

Turns the **Writing** feature into a deliberate "Coming Soon" experience instead of a disabled nav placeholder.

- **Navbar** ([Nav.tsx](src/components/Nav.tsx)): the **Writing** item now links to `/writing` and renders as a regular nav item — the disabled `<span>` (desktop) and "Soon" badge (mobile) placeholder branches were removed. The footer's Writing link ([Footer.tsx](src/components/Footer.tsx)) was updated to match (was a `null` placeholder).
- **`/writing` route** ([page.tsx](src/app/writing/page.tsx)) (new): a polished, vertically + horizontally centered "Coming Soon." placeholder that matches the design system — Instrument Serif display heading with a dimmed first word, Visby CF eyebrow, Inter muted copy, a subtle lucide `PenLine` icon mark, and a pill CTA back to `/works`. No new dependencies or assets.

## No vertical scroll on desktop

Per request, the page fits within the viewport without scrolling on desktop:
- The section centers via `flex-1` + `justify-center` (`md:py-0`, removing a redundant `py-24`).
- A scoped `body:has([data-fit-viewport]) footer { margin-top: 0 }` rule in `globals.css` drops the footer's standard 120px top gap **on this page only**.

Verified live (Playwright) — **0px overflow** at 1920×1080, 1536×864, 1440×900, 1366×768, and 1280×720. The footer's gap is unchanged on every other page.

## Constraints honored

- Routing structure unchanged; no new dependencies or external assets.
- Reuses existing layout/components and styling conventions (mirrors the contact page).
- Responsive across mobile/tablet/desktop (mobile retains normal scrolling, which is correct for short portrait viewports).
- `pnpm lint` passes.

## Notes

- `:has()` is supported in all current evergreen browsers; older browsers simply fall back to the prior scroll behavior (no breakage).
- `CHANGELOG.md` and `PLAN.md` updated per the repo's end-of-session checklist.